### PR TITLE
Fix for creating an entity with a private constructor.

### DIFF
--- a/GraphDiff/GraphDiff.Tests/GraphDiff.Tests.csproj
+++ b/GraphDiff/GraphDiff.Tests/GraphDiff.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Tests\ErrorHandlingBehaviours.cs" />
     <Compile Include="Tests\AssociatedEntityBehaviours.cs" />
     <Compile Include="Tests\AddAggregateBehaviours.cs" />
+    <Compile Include="Tests\PrivateConstructorBehaviours.cs" />
     <Compile Include="Tests\QueryLoaderBehaviours.cs" />
     <Compile Include="Tests\ThirdTierBehaviours.cs" />
     <Compile Include="Tests\MiscBehaviours.cs" />

--- a/GraphDiff/GraphDiff.Tests/Models/TestModels.cs
+++ b/GraphDiff/GraphDiff.Tests/Models/TestModels.cs
@@ -36,6 +36,21 @@ namespace RefactorThis.GraphDiff.Tests.Models
         //public ICollection<ManyToManyModel> ManyToManyAssociated { get; set; }
     }
 
+    public class TestNodeWithPrivateConstructor : Entity
+    {
+        private TestNodeWithPrivateConstructor()
+        {
+        }
+
+        public static TestNodeWithPrivateConstructor Create(string title)
+        {
+            return new TestNodeWithPrivateConstructor
+            {
+                Title = title
+            };
+        }
+    }
+
     public class NodeGroup : Entity
     {
         public List<GroupedTestNode> Members { get; set; }

--- a/GraphDiff/GraphDiff.Tests/TestDbContext.cs
+++ b/GraphDiff/GraphDiff.Tests/TestDbContext.cs
@@ -8,6 +8,7 @@ namespace RefactorThis.GraphDiff.Tests
 	public class TestDbContext : DbContext
 	{
         public IDbSet<TestNode> Nodes { get; set; }
+        public IDbSet<TestNodeWithPrivateConstructor> NodesWithPrivateConstructor { get; set; }
         public IDbSet<TestNodeWithBaseReference> NodesWithReference { get; set; }
 
         public IDbSet<NodeGroup> NodeGroups { get; set; }

--- a/GraphDiff/GraphDiff.Tests/Tests/PrivateConstructorBehaviours.cs
+++ b/GraphDiff/GraphDiff.Tests/Tests/PrivateConstructorBehaviours.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RefactorThis.GraphDiff.Tests.Models;
+
+namespace RefactorThis.GraphDiff.Tests.Tests
+{
+    [TestClass]
+    public class PrivateConstructorBehaviours : TestBase
+    {
+        [TestMethod]
+        public void ShouldCreateEntityWithPrivateConstructor()
+        {
+            var node1 = TestNodeWithPrivateConstructor.Create("Hello");
+
+            using (var context = new TestDbContext())
+            {
+                node1 = context.UpdateGraph(node1);
+                context.SaveChanges();
+                Assert.IsNotNull(context.NodesWithPrivateConstructor.SingleOrDefault(p => p.Id == node1.Id));
+            }
+        }
+    }
+}

--- a/GraphDiff/GraphDiff/DbContextExtensions.cs
+++ b/GraphDiff/GraphDiff/DbContextExtensions.cs
@@ -27,7 +27,7 @@ namespace RefactorThis.GraphDiff
         /// <param name="mapping">The mapping configuration to define the bounds of the graph</param>
         /// <param name="updateParams">Update configuration overrides</param>
         /// <returns>The attached entity graph</returns>
-        public static T UpdateGraph<T>(this DbContext context, T entity, Expression<Func<IUpdateConfiguration<T>, object>> mapping, UpdateParams updateParams = null) where T : class, new()
+        public static T UpdateGraph<T>(this DbContext context, T entity, Expression<Func<IUpdateConfiguration<T>, object>> mapping, UpdateParams updateParams = null) where T : class
 	    {
             return UpdateGraph<T>(context, entity, mapping, null, updateParams);
 	    }
@@ -41,7 +41,7 @@ namespace RefactorThis.GraphDiff
         /// <param name="mappingScheme">Pre-configured mappingScheme</param>
         /// <param name="updateParams">Update configuration overrides</param>
         /// <returns>The attached entity graph</returns>
-        public static T UpdateGraph<T>(this DbContext context, T entity, string mappingScheme, UpdateParams updateParams = null) where T : class, new()
+        public static T UpdateGraph<T>(this DbContext context, T entity, string mappingScheme, UpdateParams updateParams = null) where T : class
         {
             return UpdateGraph<T>(context, entity, null, mappingScheme, updateParams);
         }
@@ -54,7 +54,7 @@ namespace RefactorThis.GraphDiff
         /// <param name="entity">The root entity.</param>
         /// <param name="updateParams">Update configuration overrides</param>
         /// <returns>The attached entity graph</returns>
-        public static T UpdateGraph<T>(this DbContext context, T entity, UpdateParams updateParams = null) where T : class, new()
+        public static T UpdateGraph<T>(this DbContext context, T entity, UpdateParams updateParams = null) where T : class
         {
             return UpdateGraph<T>(context, entity, null, null, updateParams);
         }
@@ -85,7 +85,7 @@ namespace RefactorThis.GraphDiff
 
         // other methods are convenience wrappers around this.
         private static T UpdateGraph<T>(this DbContext context, T entity, Expression<Func<IUpdateConfiguration<T>, object>> mapping,
-                                                        string mappingScheme, UpdateParams updateParams) where T : class, new()
+                                                        string mappingScheme, UpdateParams updateParams) where T : class
         {
             GraphNode root;
             GraphDiffer<T> differ;

--- a/GraphDiff/GraphDiff/Internal/GraphDiffer.cs
+++ b/GraphDiff/GraphDiff/Internal/GraphDiffer.cs
@@ -45,7 +45,7 @@ namespace RefactorThis.GraphDiff.Internal
                 {
                     // we are always working with 2 graphs, simply add a 'persisted' one if none exists,
                     // this ensures that only the changes we make within the bounds of the mapping are attempted.
-                    persisted = Activator.CreateInstance<T>();
+                    persisted = _dbContext.Set<T>().Create();
                     _dbContext.Set<T>().Add(persisted);
                 }
 


### PR DESCRIPTION
Fix for issue #72.

Added a test for creating an entity with a private constructor. Removed new() constraints.

I used DbSet<T>.Create() to create an entity. This will only create a proxy class when the DbContext is configured to do so. So I think that is the desired behaviour.
