### PR TITLE
Private constructors for nav property entities

### DIFF
--- a/GraphDiff/GraphDiff/Internal/EntityManager.cs
+++ b/GraphDiff/GraphDiff/Internal/EntityManager.cs
@@ -67,7 +67,7 @@ namespace RefactorThis.GraphDiff.Internal
 
         public object CreateEmptyEntityWithKey(object entity)
         {
-            var instance = Activator.CreateInstance(entity.GetType());
+            var instance = Activator.CreateInstance(entity.GetType(), true);
             CopyPrimaryKeyFields(entity, instance);
             return instance;
         }

--- a/GraphDiff/GraphDiff/Internal/Graph/OwnedEntityGraphNode.cs
+++ b/GraphDiff/GraphDiff/Internal/Graph/OwnedEntityGraphNode.cs
@@ -50,7 +50,7 @@ namespace RefactorThis.GraphDiff.Internal.Graph
 
         private object CreateNewPersistedEntity<T>(IChangeTracker changeTracker, T existing, object newValue) where T : class
         {
-            var instance = Activator.CreateInstance(newValue.GetType());
+            var instance = Activator.CreateInstance(newValue.GetType(), true);
             SetValue(existing, instance);
             changeTracker.AddItem(instance);
             changeTracker.UpdateItem(newValue, instance, true);


### PR DESCRIPTION
While https://github.com/refactorthis/GraphDiff/pull/80 allowed for a top-level entity with a private constructor, if any of the navigation properties had private constructors, GraphDiff would fail because Activator.CreateInstance would fail.

I've used the alternative Activate.CreateInstance call that allows for private constructors.
