### PR TITLE
added persisted object injection

### DIFF
--- a/GraphDiff/GraphDiff/Internal/GraphDiffer.cs
+++ b/GraphDiff/GraphDiff/Internal/GraphDiffer.cs
@@ -6,7 +6,7 @@ namespace RefactorThis.GraphDiff.Internal
 {
     internal interface IGraphDiffer<T> where T : class
     {
-        T Merge(T updating, QueryMode queryMode = QueryMode.SingleQuery);
+        T Merge(T updating, T persisted, QueryMode queryMode = QueryMode.SingleQuery);
     }
 
     /// <summary>GraphDiff main entry point.</summary>
@@ -26,7 +26,7 @@ namespace RefactorThis.GraphDiff.Internal
             _entityManager = entityManager;
         }
 
-        public T Merge(T updating, QueryMode queryMode = QueryMode.SingleQuery)
+        public T Merge(T updating, T persisted, QueryMode queryMode = QueryMode.SingleQuery)
         {
             // todo query mode
             bool isAutoDetectEnabled = _dbContext.Configuration.AutoDetectChangesEnabled;
@@ -37,7 +37,11 @@ namespace RefactorThis.GraphDiff.Internal
 
                 // Get our entity with all includes needed, or add a new entity
                 var includeStrings = _root.GetIncludeStrings(_entityManager);
-                T persisted = _queryLoader.LoadEntity(updating, includeStrings, queryMode);
+
+                if (persisted == null)
+                {
+                    persisted = _queryLoader.LoadEntity(updating, includeStrings, queryMode);
+                }
 
                 if (persisted == null)
                 {
@@ -52,7 +56,7 @@ namespace RefactorThis.GraphDiff.Internal
                 {
                     throw new InvalidOperationException(
                             String.Format("Entity of type '{0}' is already in an attached state. GraphDiff supports detached entities only at this time. Please try AsNoTracking() or detach your entites before calling the UpdateGraph method.",
-                                          typeof (T).FullName));
+                                          typeof(T).FullName));
                 }
 
                 // Perform recursive update


### PR DESCRIPTION
Hi guys,

I am working on an enterprise project where the main entity is very complex, quite  few OwnedCollections in other OwnedCollections etc.The first update takes around 10 second using GraphDiff because of loading the entity in the GraphDiffer.Merge method. After the query compilation, the query is cached by EF but only for that specific entity with that specific key, if another entity is updated, the first update takes again 10 seconds.

I extended DbContextExtensions with another method where the already loaded  entity can be provided, this way the LoadEntity is skipped and only the Merge happens:   

 public static T UpdateGraph<T>(this DbContext context, T entity, T persisted, Expression<Func<IUpdateConfiguration<T>, object>> mapping) where T : class

If you will accept the pull request, I will create the necessary unit tests and then notify you for merge.

I think that too many parameters are passed around in the DbContextExtensions  UpdateGraph methods overloads, maybe a parameter class would be helpful there.

Cheers,

Tibi
