### PR TITLE
Fixing Many to Many Association error w/Proxies

### DIFF
--- a/GraphDiff/GraphDiff/Internal/EntityManager.cs
+++ b/GraphDiff/GraphDiff/Internal/EntityManager.cs
@@ -76,7 +76,7 @@ namespace RefactorThis.GraphDiff.Internal
         {
             var metadata = ObjectContext.MetadataWorkspace
                     .GetItems<EntityType>(DataSpace.OSpace)
-                    .SingleOrDefault(p => p.FullName == entityType.FullName);
+                    .SingleOrDefault(p => p.FullName == ObjectContext.GetObjectType(entityType).FullName);
 
             if (metadata == null)
             {


### PR DESCRIPTION
Fix for issue #122: InvalidOperationException: "The type System.Data.Entity.DynamicProxies.x is not known to the DbContext."
