### PR TITLE
Adding a unit test to demonstrate and detect issue #116

### DIFF
--- a/GraphDiff/GraphDiff.Tests/Models/TestModels.cs
+++ b/GraphDiff/GraphDiff.Tests/Models/TestModels.cs
@@ -112,6 +112,26 @@ namespace RefactorThis.GraphDiff.Tests.Models
         public Guid? Id { get; set; }
     }
 
+    public class TestNodeForIListMultiAddition : Entity
+    {
+        // If you change this to ICollection, then test TestIListOwnedCollectionAdditionDoesNotMultiAdd will pass
+        public IList<TestSubNodeForIListMultiAddition> SubNodes { get; set; }
+    }
+
+    public class TestSubNodeForIListMultiAddition
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.None)]
+        [Column(Order = 1)]
+        public int TestNodeForIListMultiAdditionId { get; set; }
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.None)]
+        [Column(Order = 2)]
+        public int OtherKeyId { get; set; }
+
+        public string Title { get; set; }
+    }
+
     // ====================================
     // Second tier models
     // ====================================

--- a/GraphDiff/GraphDiff.Tests/TestDbContext.cs
+++ b/GraphDiff/GraphDiff.Tests/TestDbContext.cs
@@ -4,8 +4,8 @@ using RefactorThis.GraphDiff.Tests.Tests;
 
 namespace RefactorThis.GraphDiff.Tests
 {
-	public class TestDbContext : DbContext
-	{
+    public class TestDbContext : DbContext
+    {
         public IDbSet<TestNode> Nodes { get; set; }
         public IDbSet<TestNodeWithBaseReference> NodesWithReference { get; set; }
 
@@ -16,7 +16,7 @@ namespace RefactorThis.GraphDiff.Tests
         public IDbSet<OneToManyAssociatedModel> OneToManyAssociatedModels { get; set; }
         public IDbSet<OneToManyOwnedModel> OneToManyOwnedModels { get; set; }
 
-	    public IDbSet<MultiKeyModel>  MultiKeyModels { get; set; }
+        public IDbSet<MultiKeyModel> MultiKeyModels { get; set; }
 
         public IDbSet<RootEntity> RootEntities { get; set; }
 
@@ -25,9 +25,15 @@ namespace RefactorThis.GraphDiff.Tests
         public IDbSet<InternalKeyModel> InternalKeyModels { get; set; }
         public IDbSet<NullableKeyModel> NullableKeyModels { get; set; }
 
-		protected override void OnModelCreating(DbModelBuilder modelBuilder)
-		{
+        public IDbSet<TestNodeForIListMultiAddition> TestNodesForIListMultiAddition { get; set; }
+        public IDbSet<TestSubNodeForIListMultiAddition> TestSubNodesForIListMultiAddition { get; set; }
+
+
+        protected override void OnModelCreating(DbModelBuilder modelBuilder)
+        {
+
             // second tier mappings
+            modelBuilder.Entity<TestNodeForIListMultiAddition>().HasMany(p => p.SubNodes).WithRequired().HasForeignKey(s => s.TestNodeForIListMultiAdditionId).WillCascadeOnDelete(true);
 
             modelBuilder.Entity<TestNode>().HasOptional(p => p.OneToOneAssociated).WithOptionalPrincipal(p => p.OneParent);
             modelBuilder.Entity<TestNode>().HasMany(p => p.OneToManyAssociated).WithOptional(p => p.OneParent);
@@ -61,9 +67,9 @@ namespace RefactorThis.GraphDiff.Tests
 
             modelBuilder.Entity<InternalKeyModel>()
                     .HasMany(ikm => ikm.Associates)
-		            .WithRequired(ikm => ikm.Parent);
-		}
+                           .WithRequired(ikm => ikm.Parent);
+        }
 
-		public TestDbContext() : base("GraphDiff") {}
-	}
+        public TestDbContext() : base("GraphDiff") { }
+    }
 }

--- a/GraphDiff/GraphDiff.Tests/Tests/OwnedCollectionBehaviours.cs
+++ b/GraphDiff/GraphDiff.Tests/Tests/OwnedCollectionBehaviours.cs
@@ -11,6 +11,36 @@ namespace RefactorThis.GraphDiff.Tests.Tests
     public class OwnedCollectionBehaviours : TestBase
     {
         [TestMethod]
+        public void TestIListOwnedCollectionAdditionDoesNotMultiAdd()
+        {
+            TestNodeForIListMultiAddition rootNode = new TestNodeForIListMultiAddition()
+            {
+                Title = "rootnode",
+                SubNodes = new List<TestSubNodeForIListMultiAddition>()
+            };
+
+
+            using (TestDbContext context = new TestDbContext())
+            {
+                context.TestNodesForIListMultiAddition.Add(rootNode);
+                context.SaveChanges();
+            }
+
+            rootNode.SubNodes.Add(new TestSubNodeForIListMultiAddition() { TestNodeForIListMultiAdditionId = rootNode.Id, OtherKeyId = 1, Title = "sub1" });
+            rootNode.SubNodes.Add(new TestSubNodeForIListMultiAddition() { TestNodeForIListMultiAdditionId = rootNode.Id, OtherKeyId = 2, Title = "sub2" });
+
+            using (TestDbContext context = new TestDbContext())
+            {
+                var result = context.UpdateGraph(rootNode, mapping => mapping.OwnedCollection(p => p.SubNodes));
+
+                Assert.AreEqual(2, result.SubNodes.Count);
+                Assert.AreEqual(1, result.SubNodes.Count(s => s.Title.Equals("sub1")));
+                Assert.AreEqual(1, result.SubNodes.Count(s => s.Title.Equals("sub2")));
+            }
+        }
+
+
+        [TestMethod]
         public void ShouldUpdateItemInOwnedCollection()
         {
             var node1 = new TestNode


### PR DESCRIPTION
Create a parent-child model where the child has a FK reference to
the parent. Have the parent have an IList collection of children.

EF will automatically put a HashSet in for ICollection, so it must
be IList to demonstrate the issue.

The test then uses OwnedCollection to demonstrate multiple adding
of children to the parent element. The test will fail accordingly when it expects to get 2 children but instead gets 4.

Referencing issue #116
